### PR TITLE
soong: explicitly specify name of Cardinal variables struct

### DIFF
--- a/android/variable.go
+++ b/android/variable.go
@@ -89,7 +89,7 @@ type variableProperties struct {
 		}
 
 		// include Cardinal variables
-		*android.Product_variables
+		Cardinal android.Product_variables
 	} `android:"arch_variant"`
 }
 
@@ -157,7 +157,7 @@ type productVariables struct {
 	Override_rs_driver *string `json:",omitempty"`
 
 	// include Cardinal variables
-	*android.ProductVariables
+	Cardinal android.ProductVariables
 }
 
 func boolPtr(v bool) *bool {


### PR DESCRIPTION
This seems to be needed for TARGET_USES_NON_TREBLE_CAMERA 